### PR TITLE
Improve hero layout and interactions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -70,6 +70,11 @@ h1,h2,h3,h4,h5,h6,
   transform: translateY(0%);
   z-index: 0;
 }
+.hero-bleed { /* full-width hero breakout */
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
 #particles-js { position: absolute; inset: 0; z-index: 1; pointer-events: none; }
 .hero-content { position: relative; z-index: 2; text-align: center; }
 .hero-title { font-size: clamp(2.5rem,6vw,4.5rem); text-shadow: 0 0 10px #0008; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,6 +14,12 @@
       }
     });
 
+    // ---- Hover sound placeholder ----
+    var hoverSound = new Howl({ src: ['assets/sounds/hover.wav'], volume: 0.4 });
+    document.querySelectorAll('a, button').forEach(function(el){
+      el.addEventListener('mouseenter', function(){ hoverSound.play(); });
+    });
+
     // ---- Tilt effect ----
     document.querySelectorAll('[data-tilt]').forEach(function(el){
       var height = el.clientHeight;

--- a/index.html
+++ b/index.html
@@ -71,15 +71,8 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
 
 
 <!-- ============================= HERO SECTION ============================= -->
-<header class="hero-section">
-<<<<<<< HEAD
-  <div
-  class="hero-bg"
-  style="background-image:url('assets/videos/Index_Wallpaper.gif');">
-</div>
-=======
+<header class="hero-section hero-bleed">
   <div class="hero-bg" style="background-image:url('{{ "/assets/videos/Index_Wallpaper.gif" | relative_url }}');"></div>
->>>>>>> origin/main
   <div id="particles-js"></div>
 
   <div class="hero-content text-center">
@@ -118,15 +111,6 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
     <h2 class="mb-4">Gallery</h2>
     <div class="row g-4">
       <div class="col-md-4">
-<<<<<<< HEAD
-        <img src="assets/images/quest-placeholder1.png" class="img-fluid rounded hover-lift" alt="Gallery image 1">
-      </div>
-      <div class="col-md-4">
-        <img src="assets/images/quest-placeholder2.png" class="img-fluid rounded hover-lift" alt="Gallery image 2">
-      </div>
-      <div class="col-md-4">
-        <img src="assets/images/quest-placeholder3.jpeg" class="img-fluid rounded hover-lift" alt="Gallery image 3">
-=======
         <img src="{{ 'assets/images/quest-placeholder1.png' | relative_url }}" class="img-fluid rounded hover-lift" alt="Gallery image 1">
       </div>
       <div class="col-md-4">
@@ -134,7 +118,6 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
       </div>
       <div class="col-md-4">
         <img src="{{ 'assets/images/quest-placeholder3.jpeg' | relative_url }}" class="img-fluid rounded hover-lift" alt="Gallery image 3">
->>>>>>> origin/main
       </div>
     </div>
   </div>
@@ -193,17 +176,13 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
     <div class="row g-4">
       <!-- Quest 1 -->
       <div class="col-md-6 col-lg-4">
-<<<<<<< HEAD
-        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('assets/images/quest-placeholder1.png');">
-=======
-        <div class="flip-card h-100 hover-lift" data-tilt>
->>>>>>> origin/main
+        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('{{ 'assets/images/quest-placeholder1.png' | relative_url }}');">
           <div class="flip-card-inner">
             <div class="flip-front">
               <i class="fa-solid fa-ticket display-4 text-warning mb-3"></i>
             </div>
             <div class="flip-back">
-              <img src="assets/images/quest-placeholder1.png"
+          <img src="{{ 'assets/images/quest-placeholder1.png' | relative_url }}"
                    alt="Ticket System screenshot">
             </div>
           </div>
@@ -212,17 +191,13 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
 
       <!-- Quest 2 -->
       <div class="col-md-6 col-lg-4">
-<<<<<<< HEAD
-        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('assets/images/quest-placeholder2.png');">
-=======
-        <div class="flip-card h-100 hover-lift" data-tilt>
->>>>>>> origin/main
+        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('{{ 'assets/images/quest-placeholder2.png' | relative_url }}');">
           <div class="flip-card-inner">
             <div class="flip-front">
               <i class="fa-solid fa-folder-tree display-4 text-warning mb-3"></i>
             </div>
             <div class="flip-back">
-              <img src="assets/images/quest-placeholder2.png"
+          <img src="{{ 'assets/images/quest-placeholder2.png' | relative_url }}"
                    alt="Document Manager screenshot">
             </div>
           </div>
@@ -231,17 +206,13 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
 
       <!-- Quest 3 -->
       <div class="col-md-6 col-lg-4">
-<<<<<<< HEAD
-        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('assets/images/quest-placeholder3.jpeg');">
-=======
-        <div class="flip-card h-100 hover-lift" data-tilt>
->>>>>>> origin/main
+        <div class="flip-card h-100 hover-lift" data-tilt style="--bg-img:url('{{ 'assets/images/quest-placeholder3.jpeg' | relative_url }}');">
           <div class="flip-card-inner">
             <div class="flip-front">
               <i class="fa-solid fa-cubes-stacked display-4 text-warning mb-3"></i>
             </div>
             <div class="flip-back">
-              <img src="assets/images/quest-placeholder3.jpeg"
+          <img src="{{ 'assets/images/quest-placeholder3.jpeg' | relative_url }}"
                    alt="Odoo ERP screenshot">
             </div>
           </div>
@@ -295,6 +266,14 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
         'max-glare': 0.20,
       });
     }
+
+    /* ----- sound triggers ----- */
+    const heroSound = new Howl({ src: ['assets/sounds/hero.wav'], volume: 0.5 });
+    const flipSound = new Howl({ src: ['assets/sounds/flip.wav'], volume: 0.5 });
+    heroSound.play();
+    document.querySelectorAll('.flip-card').forEach(card => {
+      card.addEventListener('mouseenter', () => flipSound.play());
+    });
   });
 
   /* ---------------- tsParticles  ------------------------------------- */
@@ -345,6 +324,17 @@ extra_css: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.mi
         y: 30,
         duration: 0.8,
         scrollTrigger: { trigger: sec, start: 'top 80%' },
+      });
+    });
+
+    /* Flip-card entrance */
+    gsap.utils.toArray('.flip-card').forEach(card => {
+      gsap.from(card, {
+        opacity: 0,
+        y: 40,
+        duration: 0.6,
+        ease: 'power1.out',
+        scrollTrigger: { trigger: card, start: 'top 85%' }
       });
     });
   }


### PR DESCRIPTION
## Summary
- center hero section edge-to-edge with new `.hero-bleed`
- clean merge leftovers and use relative paths
- animate flip cards on scroll and trigger sound effects
- add hover/hero sound placeholders

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fe8c9cf083339835a2cf26f0fd30